### PR TITLE
Fix spring erroring when no damping is supplied

### DIFF
--- a/src/spring.lua
+++ b/src/spring.lua
@@ -6,7 +6,7 @@
 local Config = require(script.Parent.Config)
 
 return function(value, stiffness, damping)
-    if damping <= 0 then
+    if damping and damping <= 0 then
         warn(("damping is %f - this spring will oscillate indefinitely! Traceback:\n%s"):format(
             damping,
             debug.traceback()


### PR DESCRIPTION
Stiffness and damping fall back to the config's defaults when not supplied, so I figure these are optional. Right now the spring errors out with `attempt to compare nil with number` when you don't pass in the damping, this quick fix takes care of that.